### PR TITLE
Updated rubocop rules

### DIFF
--- a/.rubocop-rails-modern.yml
+++ b/.rubocop-rails-modern.yml
@@ -1,0 +1,23 @@
+require: rubocop-rails
+inherit_from:
+  - .rubocop-ruby-modern.yml
+
+# Layout rules (moved from Metrics namespace)
+Layout/BlockLength:
+  Exclude:
+    - 'app/views/**/*.xml.builder'
+
+# Rails rules
+Rails/SkipsModelValidations:
+  AllowedMethods:
+    - touch
+
+# Global configuration
+AllCops:
+  Exclude:
+    - 'bin/**/*'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'node_modules/**/*'
+    - 'test/**/*'
+    - 'Rakefile'

--- a/.rubocop-ruby-modern.yml
+++ b/.rubocop-ruby-modern.yml
@@ -1,0 +1,58 @@
+# Modern RuboCop configuration for Ruby projects
+# This file uses current rule names as of RuboCop 1.50+
+
+# Style rules
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/ReturnNil:
+  Enabled: true
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/Lambda:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
+  Enabled: false
+
+Style/MixedRegexpCaptureTypes:
+  Enabled: false
+
+Style/KeywordParametersOrder:
+  Enabled: false
+
+# Documentation rules
+Style/Documentation:
+  Enabled: false
+
+# Layout rules
+Layout/LineLength:
+  Max: 120
+
+# Metrics rules
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+# Naming rules
+Naming/MethodParameterName:
+  AllowedNames:
+    - x
+    - y
+    - ph
+    - pw
+    - ip
+    - id

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 This project is a collection of EIF-specific style guides. It's recommended to point all projects to use this repo, instead of copy-pasting.
 
 Example of Code Climate configuration: https://docs.codeclimate.com/v1.0/docs/configuring-the-prepare-step
+
+Since on 2025 CodeClimate was migrated to Qlty.sh tool that uses modern Rubocop naming conventions rules were also updated.
+
+Codeclimate | Qlty.sh 
+- | -
+rubocop-rails.yml | rubocop-rails-modern.yml
+rubocop-ruby.yml | rubocop-ruby-modern.yml
+
+Qlty configuration: https://docs.qlty.sh/qlty-toml


### PR DESCRIPTION
Since 2025 codeclimate was replaced by Qlty.sh https://docs.qlty.sh/what-is-qlty and previously
was used outdated rubocop naming conventions, new files '...modern' has added with correct rubocop naming convention.